### PR TITLE
Fix abort signal support

### DIFF
--- a/src/hooks/useOfflineDetection.ts
+++ b/src/hooks/useOfflineDetection.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { timeoutSignal } from '../lib/utils';
 
 export interface OfflineState {
   isOffline: boolean;
@@ -21,7 +22,7 @@ export function useOfflineDetection() {
       const response = await fetch('https://arrivelah2.busrouter.sg/?id=10389', {
         method: 'HEAD',
         cache: 'no-cache',
-        signal: AbortSignal.timeout(5000), // 5 second timeout
+        signal: timeoutSignal(5000), // 5 second timeout
       });
       return response.ok;
     } catch {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,13 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function timeoutSignal(ms: number): AbortSignal {
+  const timeout = (AbortSignal as { timeout?: (ms: number) => AbortSignal }).timeout
+  if (typeof timeout === 'function') {
+    return timeout(ms)
+  }
+  const controller = new AbortController()
+  setTimeout(() => controller.abort(), ms)
+  return controller.signal
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,5 @@
 import type { BusArrival } from '../types';
+import { timeoutSignal } from '../lib/utils';
 
 // Define types for the bus API response
 interface BusService {
@@ -38,7 +39,7 @@ export const fetchBusArrivals = async (stationId: string, busNumbers: string[]):
 
     // Use the actual Singapore bus API from arrivelah2.busrouter.sg
     const response = await fetch(`https://arrivelah2.busrouter.sg/?id=${stationId}`, {
-      signal: AbortSignal.timeout(10000), // 10 second timeout
+      signal: timeoutSignal(10000), // 10 second timeout
     });
     
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- handle browsers that lack `AbortSignal.timeout`
- use new `timeoutSignal()` helper in API and offline detection

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_683fbe2c3eb88324bd186537ac721162