### PR TITLE
Improve notification features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { About } from './components/About';
 import { OfflineModal } from './components/OfflineModal';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { useOfflineDetection } from './hooks/useOfflineDetection';
+import { usePendingNotifications } from './hooks/usePendingNotifications';
 import type { StationConfig, TabType, Theme, StopData, ServiceData, BusArrival } from './types';
 import './App.css';
 import { HomeTab } from './components/HomeTab';
@@ -39,6 +40,8 @@ function AppContent() {
     { stationId: '10389', busNumbers: ['121', '122'] },
     { stationId: '10161', busNumbers: ['121', '122'] },
   ]);
+
+  const { addNotification } = usePendingNotifications();
 
   // Offline detection
   const { isOffline, isRetrying, retryCount, lastRetryTime, manualRetry } = useOfflineDetection();
@@ -79,7 +82,8 @@ function AppContent() {
       return;
     }
 
-    const delay = Math.max(remainingTime - 60000, 0); // notify about 1 min before
+    const notifyBefore = 2 * 60 * 1000; // 2 minutes
+    const delay = Math.max(remainingTime - notifyBefore, 0);
     await schedulePush(
       subscription,
       {
@@ -88,6 +92,7 @@ function AppContent() {
       },
       delay,
     );
+    addNotification({ id: `${bus.busNo}-${Date.now()}`, busNo: bus.busNo, targetTime: Date.now() + delay });
     toast.success(`Notification set for Bus ${bus.busNo} (${minutes} min)`);
   };
 

--- a/src/components/NotificationsTab.test.tsx
+++ b/src/components/NotificationsTab.test.tsx
@@ -1,9 +1,17 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { NotificationsTab } from './NotificationsTab'
 
 describe('NotificationsTab', () => {
   it('renders heading', () => {
     const { getByText } = render(<NotificationsTab />)
     expect(getByText('Notifications')).toBeTruthy()
+  })
+
+  it('shows stored notifications and can clear', () => {
+    window.localStorage.setItem('pendingNotifications', JSON.stringify([{ id: '1', busNo: '10', targetTime: Date.now() + 1000 }]))
+    const { getByText } = render(<NotificationsTab />)
+    expect(getByText('Bus 10')).toBeTruthy()
+    fireEvent.click(getByText('Clear All'))
+    expect(window.localStorage.getItem('pendingNotifications')).toBe('[]')
   })
 })

--- a/src/components/NotificationsTab.test.tsx
+++ b/src/components/NotificationsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, waitFor } from '@testing-library/react'
 import { NotificationsTab } from './NotificationsTab'
 
 describe('NotificationsTab', () => {
@@ -7,11 +7,13 @@ describe('NotificationsTab', () => {
     expect(getByText('Notifications')).toBeTruthy()
   })
 
-  it('shows stored notifications and can clear', () => {
+  it('shows stored notifications and can clear', async () => {
     window.localStorage.setItem('pendingNotifications', JSON.stringify([{ id: '1', busNo: '10', targetTime: Date.now() + 1000 }]))
     const { getByText } = render(<NotificationsTab />)
     expect(getByText('Bus 10')).toBeTruthy()
     fireEvent.click(getByText('Clear All'))
-    expect(window.localStorage.getItem('pendingNotifications')).toBe('[]')
+    await waitFor(() => {
+      expect(window.localStorage.getItem('pendingNotifications')).toBe('[]')
+    })
   })
 })

--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -1,19 +1,72 @@
-import { Card, CardContent } from './ui/card';
-import { Bell } from 'lucide-react';
+import { useState, useEffect } from 'react'
+import { Card, CardContent, CardFooter } from './ui/card'
+import { Button } from './ui/button'
+import { Bell, X } from 'lucide-react'
+import { usePendingNotifications } from '../hooks/usePendingNotifications'
 
 export function NotificationsTab() {
+  const { notifications, removeNotification, clearNotifications } = usePendingNotifications()
+  const [now, setNow] = useState(Date.now())
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const formatRemaining = (ms: number) => {
+    if (ms <= 0) return 'Arriving'
+    const m = Math.floor(ms / 60000)
+    const s = Math.floor((ms % 60000) / 1000)
+    return `${m > 0 ? `${m}m ` : ''}${s}s`
+  }
+
   return (
     <div className="space-y-3 pb-6">
       <h2 className="text-xl font-bold">Notifications</h2>
-      <Card>
-        <CardContent className="p-3 text-center">
-          <Bell className="w-10 h-10 mx-auto mb-3 text-muted-foreground" />
-          <h3 className="text-base font-semibold mb-2">Bus Notifications</h3>
-          <p className="text-sm text-muted-foreground">
-            Tap the bell icon on any bus card to get notified before it arrives
-          </p>
-        </CardContent>
-      </Card>
+      {notifications.length === 0 ? (
+        <Card>
+          <CardContent className="p-3 text-center">
+            <Bell className="w-10 h-10 mx-auto mb-3 text-muted-foreground" />
+            <h3 className="text-base font-semibold mb-2">Bus Notifications</h3>
+            <p className="text-sm text-muted-foreground">
+              Tap the bell icon on any bus card to get notified before it arrives
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {notifications.map(n => (
+            <Card key={n.id}>
+              <CardContent className="p-3 flex justify-between items-center">
+                <div className="flex items-center gap-2">
+                  <Bell className="w-4 h-4" />
+                  <span className="font-semibold">Bus {n.busNo}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    {formatRemaining(n.targetTime - now)}
+                  </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeNotification(n.id)}
+                    className="h-6 w-6 p-0"
+                  >
+                    <X className="w-4 h-4" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+          <Card>
+            <CardFooter className="justify-end">
+              <Button variant="destructive" size="sm" onClick={clearNotifications}>
+                Clear All
+              </Button>
+            </CardFooter>
+          </Card>
+        </div>
+      )}
     </div>
-  );
-} 
+  )
+}

--- a/src/components/StationConfig.tsx
+++ b/src/components/StationConfig.tsx
@@ -43,7 +43,7 @@ export function StationConfigComponent({
     return stationId;
   };
 
-  const getStationToBusNumbers = () => {
+  const stationToBusNumbers = useMemo(() => {
     const mapping: Record<string, Set<string>> = {};
     Object.keys(servicesData).forEach(busNo => {
       servicesData[busNo].routes.forEach(route => {
@@ -69,9 +69,7 @@ export function StationConfigComponent({
       });
     });
     return mappingArrays;
-  };
-
-  const stationToBusNumbers = useMemo(() => getStationToBusNumbers(), [servicesData]);
+  }, [servicesData]);
 
   const handleStationInputChange = (value: string) => {
     setNewStationInput(value);

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -43,4 +43,4 @@ function Badge({
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -56,4 +56,4 @@ function Button({
   )
 }
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 
-export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+import type { Dispatch, SetStateAction } from 'react'
+
+export function useLocalStorage<T>(key: string, initialValue: T): [T, Dispatch<SetStateAction<T>>] {
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
       const item = window.localStorage.getItem(key);
@@ -11,10 +13,11 @@ export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T)
     }
   });
 
-  const setValue = (value: T) => {
+  const setValue: Dispatch<SetStateAction<T>> = value => {
     try {
-      setStoredValue(value);
-      window.localStorage.setItem(key, JSON.stringify(value));
+      const newValue = value instanceof Function ? value(storedValue) : value
+      setStoredValue(newValue)
+      window.localStorage.setItem(key, JSON.stringify(newValue))
     } catch (error) {
       console.error(`Error setting localStorage key "${key}":`, error);
     }

--- a/src/hooks/useNotifications.test.tsx
+++ b/src/hooks/useNotifications.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook, act } from '@testing-library/react'
+import { vi } from 'vitest'
+import { useNotifications } from './useNotifications'
+import { usePendingNotifications } from './usePendingNotifications'
+import { requestPushSubscription, schedulePush } from '../services/push'
+
+vi.mock('./usePendingNotifications')
+vi.mock('../services/push')
+
+const mockedUsePending = usePendingNotifications as unknown as any
+const mockedRequest = requestPushSubscription as unknown as any
+const mockedSchedule = schedulePush as unknown as any
+
+describe('useNotifications', () => {
+  it('schedules and saves notification', async () => {
+    mockedUsePending.mockReturnValue({ addNotification: vi.fn() })
+    mockedRequest.mockResolvedValue({})
+    const { result } = renderHook(() => useNotifications())
+    const bus = { busNo: '10', arrivalTimestamp: Date.now() + 60000 } as any
+    await act(async () => {
+      await result.current.notifyBus(bus)
+    })
+    expect(mockedSchedule).toHaveBeenCalled()
+    expect(mockedUsePending.mock.results[0].value.addNotification).toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useNotifications.test.tsx
+++ b/src/hooks/useNotifications.test.tsx
@@ -21,6 +21,21 @@ describe('useNotifications', () => {
       await result.current.notifyBus(bus)
     })
     expect(mockedSchedule).toHaveBeenCalled()
-    expect(mockedUsePending.mock.results[0].value.addNotification).toHaveBeenCalled()
+    expect(mockedUsePending.mock.results[0].value.addNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds notification once per call', async () => {
+    const addNotification = vi.fn()
+    mockedUsePending.mockReturnValue({ addNotification })
+    mockedRequest.mockResolvedValue({})
+    const { result } = renderHook(() => useNotifications())
+    const bus = { busNo: '10', arrivalTimestamp: Date.now() + 60000 } as any
+    await act(async () => {
+      await result.current.notifyBus(bus)
+    })
+    await act(async () => {
+      await result.current.notifyBus(bus)
+    })
+    expect(addNotification).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,38 @@
+import { toast } from 'sonner'
+import { requestPushSubscription, schedulePush } from '../services/push'
+import type { BusArrival } from '../types'
+import { usePendingNotifications } from './usePendingNotifications'
+
+export function useNotifications() {
+  const { addNotification } = usePendingNotifications()
+
+  const notifyBus = async (bus: BusArrival) => {
+    const remainingTime = bus.arrivalTimestamp - Date.now()
+    const minutes = Math.floor(remainingTime / (1000 * 60))
+    if (remainingTime <= 0) {
+      toast.info("Bus is arriving now!")
+      return
+    }
+
+    const subscription = await requestPushSubscription()
+    if (!subscription) {
+      toast.error('Notifications not enabled')
+      return
+    }
+
+    const notifyBefore = 2 * 60 * 1000 // 2 minutes
+    const delay = Math.max(remainingTime - notifyBefore, 0)
+    await schedulePush(
+      subscription,
+      {
+        title: `Bus ${bus.busNo} approaching`,
+        body: `Bus ${bus.busNo} will arrive soon`,
+      },
+      delay,
+    )
+    addNotification({ id: `${bus.busNo}-${Date.now()}`, busNo: bus.busNo, targetTime: Date.now() + delay })
+    toast.success(`Notification set for Bus ${bus.busNo} (${minutes} min)`)
+  }
+
+  return { notifyBus }
+}

--- a/src/hooks/usePendingNotifications.test.tsx
+++ b/src/hooks/usePendingNotifications.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook, act } from '@testing-library/react'
+import { usePendingNotifications } from './usePendingNotifications'
+
+describe('usePendingNotifications', () => {
+  it('adds and removes notifications', () => {
+    window.localStorage.clear()
+    const { result } = renderHook(() => usePendingNotifications())
+    act(() => {
+      result.current.addNotification({ id: '1', busNo: '10', targetTime: Date.now() + 1000 })
+    })
+    expect(result.current.notifications.length).toBe(1)
+    act(() => {
+      result.current.removeNotification('1')
+    })
+    expect(result.current.notifications.length).toBe(0)
+  })
+})

--- a/src/hooks/usePendingNotifications.test.tsx
+++ b/src/hooks/usePendingNotifications.test.tsx
@@ -14,4 +14,16 @@ describe('usePendingNotifications', () => {
     })
     expect(result.current.notifications.length).toBe(0)
   })
+
+  it('appends multiple notifications correctly', () => {
+    window.localStorage.clear()
+    const { result } = renderHook(() => usePendingNotifications())
+    act(() => {
+      result.current.addNotification({ id: '1', busNo: '10', targetTime: 1 })
+    })
+    act(() => {
+      result.current.addNotification({ id: '2', busNo: '20', targetTime: 2 })
+    })
+    expect(result.current.notifications.length).toBe(2)
+  })
 })

--- a/src/hooks/usePendingNotifications.ts
+++ b/src/hooks/usePendingNotifications.ts
@@ -1,0 +1,25 @@
+import { useLocalStorage } from './useLocalStorage'
+
+export interface PendingNotification {
+  id: string
+  busNo: string
+  targetTime: number
+}
+
+export function usePendingNotifications() {
+  const [notifications, setNotifications] = useLocalStorage<PendingNotification[]>('pendingNotifications', [])
+
+  const addNotification = (notification: PendingNotification) => {
+    setNotifications([...notifications, notification])
+  }
+
+  const removeNotification = (id: string) => {
+    setNotifications(notifications.filter(n => n.id !== id))
+  }
+
+  const clearNotifications = () => {
+    setNotifications([])
+  }
+
+  return { notifications, addNotification, removeNotification, clearNotifications }
+}

--- a/src/hooks/usePendingNotifications.ts
+++ b/src/hooks/usePendingNotifications.ts
@@ -10,11 +10,11 @@ export function usePendingNotifications() {
   const [notifications, setNotifications] = useLocalStorage<PendingNotification[]>('pendingNotifications', [])
 
   const addNotification = (notification: PendingNotification) => {
-    setNotifications([...notifications, notification])
+    setNotifications(prev => [...prev, notification])
   }
 
   const removeNotification = (id: string) => {
-    setNotifications(notifications.filter(n => n.id !== id))
+    setNotifications(prev => prev.filter(n => n.id !== id))
   }
 
   const clearNotifications = () => {


### PR DESCRIPTION
## Summary
- add hook for pending notifications
- display pending notifications with countdown and ability to clear in the Alerts tab
- schedule notifications 2 minutes before arrival and track them
- test new hook and NotificationsTab behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684068e13f348324894c13fcea4f67d2