### PR TITLE
Add simple email login sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test --silent
+      - run: pnpm build

--- a/netlify/functions/user-settings.ts
+++ b/netlify/functions/user-settings.ts
@@ -1,0 +1,38 @@
+import { Handler } from '@netlify/functions'
+import { connectLambda, getStore } from '@netlify/blobs'
+import type { LambdaEvent } from '@netlify/serverless-functions-api/dist/lambda/event'
+
+const handler: Handler = async (event) => {
+  if ((event as { blobs?: string }).blobs) {
+    try {
+      connectLambda(event as unknown as LambdaEvent)
+    } catch {
+      /* ignore errors */
+    }
+  }
+  const store = getStore('user-settings')
+  const method = event.httpMethod || 'GET'
+  let email = event.queryStringParameters?.email as string | undefined
+  if (!email && event.body) {
+    try {
+      email = JSON.parse(event.body).email
+    } catch {
+      /* ignore errors */
+    }
+  }
+  if (!email) return { statusCode: 400, body: 'Email required' }
+  const key = encodeURIComponent(email.trim().toLowerCase())
+
+  if (method === 'GET') {
+    const data = await store.get(key, { type: 'json' })
+    return { statusCode: 200, body: JSON.stringify(data) }
+  }
+  if (method === 'POST') {
+    const { data } = event.body ? JSON.parse(event.body) : { data: null }
+    await store.setJSON(key, data)
+    return { statusCode: 200, body: 'ok' }
+  }
+  return { statusCode: 405, body: 'Method Not Allowed' }
+}
+
+export { handler }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@netlify/blobs": "^9.1.5",
     "@netlify/functions": "^4.1.2",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@netlify/blobs':
+        specifier: ^9.1.5
+        version: 9.1.5
       '@netlify/functions':
         specifier: ^4.1.2
         version: 4.1.2(rollup@2.79.2)

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -58,10 +58,11 @@ export function SettingsTab({
       <h2 className="text-xl font-bold">Settings</h2>
       {/* Login */}
       <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="flex items-center text-base">
-            Account
-          </CardTitle>
+        <CardHeader className="pb-2 space-y-1">
+          <CardTitle className="text-base">Account</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Sync your favourite stations across devices by signing in with your email.
+          </p>
         </CardHeader>
         <CardContent className="pt-0">
           {email ? (
@@ -73,7 +74,7 @@ export function SettingsTab({
             <form onSubmit={handleLogin} className="flex gap-2">
               <Input
                 type="email"
-                placeholder="Email"
+                placeholder="you@example.com"
                 value={emailInput}
                 onChange={(e) => setEmailInput(e.target.value)}
                 className="flex-1 text-base placeholder:text-base"

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -1,8 +1,13 @@
-import { Card, CardHeader, CardTitle, CardContent } from './ui/card';
-import { Button } from './ui/button';
-import { Sun, Moon } from 'lucide-react';
-import { StationConfigComponent } from './StationConfig';
-import type { StationConfig, Theme, StopData, ServiceData } from '../types';
+import { useState, useEffect } from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
+import { Button } from './ui/button'
+import { Input } from './ui/input'
+import { Sun, Moon } from 'lucide-react'
+import { toast } from 'sonner'
+import { StationConfigComponent } from './StationConfig'
+import { useLocalStorage } from '../hooks/useLocalStorage'
+import { fetchUserSettings, saveUserSettings } from '../services/user'
+import type { StationConfig, Theme, StopData, ServiceData } from '../types'
 
 interface SettingsTabProps {
   theme: Theme;
@@ -21,9 +26,63 @@ export function SettingsTab({
   stopsData,
   servicesData,
 }: SettingsTabProps) {
+  const [email, setEmail] = useLocalStorage<string>('userEmail', '')
+  const [emailInput, setEmailInput] = useState(email)
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const value = emailInput.trim()
+    if (!value) return
+    setEmail(value)
+    try {
+      const data = await fetchUserSettings(value)
+      if (data) {
+        setStationConfigs(data)
+      }
+      toast.success('Settings synced')
+    } catch {
+      toast.error('Failed to load settings')
+    }
+  }
+
+  useEffect(() => {
+    if (email) {
+      saveUserSettings(email, stationConfigs).catch(() => {
+        toast.error('Failed to sync settings')
+      })
+    }
+  }, [stationConfigs, email])
+
   return (
     <div className="space-y-3 pb-6">
       <h2 className="text-xl font-bold">Settings</h2>
+      {/* Login */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center text-base">
+            Account
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="pt-0">
+          {email ? (
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-sm break-all">{email}</span>
+              <Button size="sm" variant="outline" onClick={() => setEmail('')}>Log out</Button>
+            </div>
+          ) : (
+            <form onSubmit={handleLogin} className="flex gap-2">
+              <Input
+                type="email"
+                placeholder="Email"
+                value={emailInput}
+                onChange={(e) => setEmailInput(e.target.value)}
+                className="flex-1 text-base placeholder:text-base"
+              />
+              <Button type="submit" size="sm">Login</Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
       {/* Theme Toggle */}
       <Card>
         <CardHeader className="pb-2">

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,0 +1,17 @@
+import type { StationConfig } from '../types'
+
+const endpoint = '/.netlify/functions/user-settings'
+
+export async function fetchUserSettings(email: string): Promise<StationConfig[] | null> {
+  const res = await fetch(`${endpoint}?email=${encodeURIComponent(email)}`)
+  if (!res.ok) throw new Error('Failed to fetch')
+  return (await res.json()) as StationConfig[] | null
+}
+
+export async function saveUserSettings(email: string, data: StationConfig[]): Promise<void> {
+  await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, data })
+  })
+}


### PR DESCRIPTION
## Summary
- add `user-settings` Netlify function storing data via Netlify Blobs
- implement email login UI in settings and auto sync
- expose helpers to fetch and save user settings

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840740842508324a96b5363445e918a