### PR TITLE
Improve settings UX and add scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A modern, mobile-first Progressive Web App (PWA) for real-time bus arrival track
 - 🔔 **Smart Notifications**: Web Push alerts when buses are approaching
 - 💾 **Offline Storage**: Your settings and favorite stops are saved locally
 - 🔄 **Auto-refresh**: Automatic data updates using TanStack Query
+- ⬆️ **Tab Top Scroll**: View resets to top whenever you switch tabs
+- ➕ **One-tap Bus Numbers**: Tap a bus number suggestion to add it instantly
+- ✅ **Sync Confirmation**: Toast shown when settings are synced
 - 📲 **PWA Support**: Install as a mobile app with offline caching
 - 🚀 **Fast Loading**: Bundled with comprehensive Singapore bus stop and route data
 
@@ -81,7 +84,7 @@ The built files will be in the `dist` directory.
 1. Go to the **Settings** tab
 2. Enter a station ID or search by name in the "Add Bus Station" section
 3. Click the + button to add the station
-4. For each station, add the bus numbers you want to track
+4. Tap any bus number in the suggestions or the list of available buses to add it instantly
 
 ### Getting Notifications
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,17 @@ function AppContent() {
 
   const { notifyBus } = useNotifications();
 
+  // Scroll to top whenever the active tab changes
+  useEffect(() => {
+    if (typeof window !== 'undefined' && 'scrollTo' in window) {
+      try {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      } catch {
+        /* ignore scroll errors in tests */
+      }
+    }
+  }, [activeTab]);
+
   // Offline detection
   const { isOffline, isRetrying, retryCount, lastRetryTime, manualRetry } = useOfflineDetection();
 

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -94,6 +94,7 @@ export function SettingsTab({
     try {
       await saveUserSettings(email, authToken, stationConfigs)
       setLastSync(Date.now())
+      toast.success('Settings synced')
     } catch {
       toast.error('Failed to sync settings')
     }

--- a/src/components/StationConfig.tsx
+++ b/src/components/StationConfig.tsx
@@ -157,7 +157,7 @@ export function StationConfigComponent({
         // Show warning but still allow adding (maybe for future routes)
         console.warn(`Bus ${newBusNumber} may not serve station ${stationId}`);
       }
-      
+
       const updatedConfigs = stationConfigs.map(s => {
         if (s.stationId === stationId && !s.busNumbers.includes(newBusNumber)) {
           return { ...s, busNumbers: [...s.busNumbers, newBusNumber] };
@@ -168,6 +168,18 @@ export function StationConfigComponent({
       setNewBusNumberInputs(inputs => ({ ...inputs, [stationId]: '' }));
       setBusNumberSuggestions(suggestions => ({ ...suggestions, [stationId]: [] }));
     }
+  };
+
+  const addBusNumberDirect = (stationId: string, busNo: string) => {
+    const updatedConfigs = stationConfigs.map(s => {
+      if (s.stationId === stationId && !s.busNumbers.includes(busNo)) {
+        return { ...s, busNumbers: [...s.busNumbers, busNo] };
+      }
+      return s;
+    });
+    onUpdateConfigs(updatedConfigs);
+    setNewBusNumberInputs(inputs => ({ ...inputs, [stationId]: '' }));
+    setBusNumberSuggestions(suggestions => ({ ...suggestions, [stationId]: [] }));
   };
 
   const removeBusNumber = (stationId: string, busNo: string) => {
@@ -186,8 +198,7 @@ export function StationConfigComponent({
   };
 
   const handleBusNumberSelect = (stationId: string, busNo: string) => {
-    setNewBusNumberInputs(inputs => ({ ...inputs, [stationId]: busNo }));
-    setBusNumberSuggestions(suggestionsObj => ({ ...suggestionsObj, [stationId]: [] }));
+    addBusNumberDirect(stationId, busNo);
   };
 
   return (
@@ -330,7 +341,7 @@ export function StationConfigComponent({
                         className="min-w-[40px] min-h-[40px] h-10 px-4 py-2 text-base cursor-pointer hover:bg-accent flex items-center justify-center rounded-lg"
                         onClick={() => {
                           if (!config.busNumbers.includes(busNo)) {
-                            setNewBusNumberInputs(inputs => ({ ...inputs, [config.stationId]: busNo }));
+                            addBusNumberDirect(config.stationId, busNo);
                           }
                         }}
                       >


### PR DESCRIPTION
## Summary
- add automatic scroll to top when tabs change
- show toast after syncing settings
- allow adding bus numbers with a single tap
- document latest behaviour

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840950f47c08324b37ec0ad33da1f8d