### PR TITLE
Fix iOS safe area handling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,11 +19,18 @@ body {
   overscroll-behavior-y: none;
   -webkit-overflow-scrolling: touch;
   -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 /* Safe area support for iOS */
 .pb-safe {
   padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Safe area padding for the top iOS status bar */
+.pt-safe {
+  padding-top: env(safe-area-inset-top);
 }
 
 /* Custom scrollbar for webkit browsers */
@@ -51,11 +58,17 @@ body {
 }
 
 /* Ensure proper touch targets on mobile */
-button, 
-input, 
-select, 
+button,
+input,
+select,
 textarea {
   min-height: 44px;
+  user-select: auto;
+}
+
+img {
+  -webkit-user-drag: none;
+  user-select: none;
 }
 
 /* Mobile optimizations */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,9 +152,9 @@ function AppContent() {
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background pt-safe">
       {/* Main Content */}
-      <div className="mx-auto max-w-[480px] p-3 pb-20">
+      <div className="mx-auto max-w-[480px] p-3 pb-16">
         {renderTabContent()}
       </div>
       {/* Bottom Navigation */}


### PR DESCRIPTION
## Summary
- respect iOS top safe area for translucent status bar
- reduce bottom padding and disable text/image selection to mimic native UI

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68409af9b2a88324ac255a9b94ab4744