### PR TITLE
UI tweaks and prevent logo selection

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -69,6 +69,7 @@ textarea {
 img {
   -webkit-user-drag: none;
   user-select: none;
+  -webkit-touch-callout: none;
 }
 
 /* Mobile optimizations */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,7 +160,12 @@ function AppContent() {
       {/* Bottom Navigation */}
       <BottomNavigation activeTab={activeTab} onTabChange={setActiveTab} />
       {/* Toast Container */}
-      <Toaster richColors position="top-center" />
+      <Toaster
+        richColors
+        position="top-center"
+        offset={{ top: 'calc(env(safe-area-inset-top) + 8px)' }}
+        mobileOffset={{ top: 'calc(env(safe-area-inset-top) + 8px)' }}
+      />
       {/* Offline Modal */}
       <OfflineModal
         isOffline={isOffline}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -14,10 +14,12 @@ export function About() {
             {/* Animated background pattern */}
             <div className="absolute inset-0 opacity-10">
               <div className="absolute top-4 left-4 animate-pulse">
-                <img 
-                  src={busIcon} 
-                  alt="Bus" 
+                <img
+                  src={busIcon}
+                  alt="Bus"
                   className="w-8 h-8 bg-white dark:bg-gray-800 rounded p-1"
+                  draggable={false}
+                  onContextMenu={(e) => e.preventDefault()}
                 />
               </div>
               <div className="absolute top-8 right-8 animate-bounce">
@@ -31,10 +33,12 @@ export function About() {
             <div className="relative z-10">
               <div className="mb-4">
                 <div className="w-16 h-16 bg-white dark:bg-gray-800 rounded-xl shadow-lg p-2 mx-auto mb-2">
-                  <img 
-                    src={busIcon} 
-                    alt="SG Bus Logo" 
+                  <img
+                    src={busIcon}
+                    alt="SG Bus Logo"
                     className="w-full h-full object-contain"
+                    draggable={false}
+                    onContextMenu={(e) => e.preventDefault()}
                   />
                 </div>
               </div>

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -15,7 +15,10 @@ export function BottomNavigation({ activeTab, onTabChange }: BottomNavigationPro
   ];
 
   return (
-    <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[480px] bg-background/95 backdrop-blur-xl border-t border-border/50 z-50 pb-safe" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+    <nav
+      className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-[480px] bg-background/95 backdrop-blur-xl border-t border-border/50 z-50"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom) / 2)' }}
+    >
       <div className="flex justify-around items-center py-2 px-4">
         {tabs.map((tab) => {
           const Icon = tab.icon;

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -154,10 +154,12 @@ export function HomeTab({
         <div className="flex items-center gap-3">
           {/* Bus Logo */}
           <div className="flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-xl p-1">
-            <img 
+            <img
               src={busIcon}
-              alt="Bus Logo" 
+              alt="Bus Logo"
               className="w-full h-full object-contain"
+              draggable={false}
+              onContextMenu={(e) => e.preventDefault()}
             />
           </div>
           {/* App Title */}


### PR DESCRIPTION
## Summary
- adjust toast position to respect iOS top safe area
- reduce bottom nav padding to better align with safe area
- prevent long press selection on bus logo images
- disable iOS touch callout on images

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68409d1306348324b2790018afa43c56