### PR TITLE
Add PWA update/install prompts and geolocation weather

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react'
 import { vi } from 'vitest'
 vi.mock('./assets/bus.png', () => ({ default: '' }))
+vi.mock('@/assets/bus.png', () => ({ default: '' }))
 vi.mock('virtual:pwa-register/react', () => ({
   useRegisterSW: () => ({ needRefresh: [false, () => {}], updateServiceWorker: () => {} })
 }))

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,16 @@
 import { render } from '@testing-library/react'
 import { vi } from 'vitest'
 vi.mock('./assets/bus.png', () => ({ default: '' }))
+vi.mock('virtual:pwa-register/react', () => ({
+  useRegisterSW: () => ({ needRefresh: [false, () => {}], updateServiceWorker: () => {} })
+}))
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockReturnValue({ matches: false, addListener: vi.fn(), removeListener: vi.fn() }),
+  })
+  window.scrollTo = vi.fn()
+})
 import App from './App'
 
 describe('App', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,6 +155,7 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-background pt-safe">
+      <InstallPrompt />
       {/* Main Content */}
       <div className="mx-auto max-w-[480px] p-3 pb-16">
         {renderTabContent()}
@@ -177,7 +178,6 @@ function AppContent() {
         onRetry={handleOfflineRetry}
       />
       <UpdatePrompt />
-      <InstallPrompt />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { Toaster, toast } from 'sonner';
 import { BottomNavigation } from './components/BottomNavigation';
 import { About } from './components/About';
 import { OfflineModal } from './components/OfflineModal';
+import { UpdatePrompt } from './components/UpdatePrompt';
+import { InstallPrompt } from './components/InstallPrompt';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { useOfflineDetection } from './hooks/useOfflineDetection';
 import { useNotifications } from './hooks/useNotifications';
@@ -174,6 +176,8 @@ function AppContent() {
         lastRetryTime={lastRetryTime}
         onRetry={handleOfflineRetry}
       />
+      <UpdatePrompt />
+      <InstallPrompt />
     </div>
   );
 }

--- a/src/__mocks__/pwa-register-react.ts
+++ b/src/__mocks__/pwa-register-react.ts
@@ -1,0 +1,6 @@
+export function useRegisterSW() {
+  return {
+    needRefresh: [false, () => {}] as [boolean, (v: boolean) => void],
+    updateServiceWorker: () => {},
+  }
+}

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Download } from 'lucide-react'
 import { Button } from './ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import busIcon from '@/assets/bus.png'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 
 interface BeforeInstallPromptEvent extends Event {
@@ -49,26 +48,37 @@ export function InstallPrompt() {
   if (!show) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-sm mx-auto shadow-2xl">
-        <CardHeader className="text-center pb-4">
-          <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
-            <Download className="w-8 h-8 text-primary" />
-          </div>
-          <CardTitle className="text-xl font-semibold">Add to Home Screen</CardTitle>
-        </CardHeader>
-        <CardContent className="text-center space-y-4">
+    <div className="bg-background border-b border-border/50 shadow-sm">
+      <div className="max-w-[480px] mx-auto flex items-center gap-3 p-3">
+        <img
+          src={busIcon}
+          alt="App icon"
+          className="w-8 h-8 rounded-md flex-shrink-0"
+          draggable={false}
+          onContextMenu={(e) => e.preventDefault()}
+        />
+        <div className="flex-1 text-sm">
           {promptEvent ? (
-            <p className="text-sm text-muted-foreground">Install this app for quick access.</p>
+            <p>
+              Install <span className="font-medium">SG Bus Arrival</span> for quick access
+            </p>
           ) : (
-            <p className="text-sm text-muted-foreground">Tap Share and choose "Add to Home Screen".</p>
+            <p>
+              Tap Share and choose <span className="font-medium">Add to Home Screen</span>
+            </p>
           )}
-          <div className="flex gap-3 justify-center">
-            {promptEvent && <Button onClick={install}>Install</Button>}
-            <Button variant="outline" onClick={dismiss}>Dismiss</Button>
-          </div>
-        </CardContent>
-      </Card>
+        </div>
+        <div className="flex gap-2">
+          {promptEvent && (
+            <Button size="sm" onClick={install} className="px-3">
+              Install
+            </Button>
+          )}
+          <Button size="sm" variant="ghost" onClick={dismiss} className="px-3">
+            Dismiss
+          </Button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import { Download } from 'lucide-react'
+import { Button } from './ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+import { useLocalStorage } from '../hooks/useLocalStorage'
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>
+}
+
+function isiOS() {
+  return /iphone|ipad|ipod/i.test(navigator.userAgent)
+}
+
+export function InstallPrompt() {
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null)
+  const [dismissedAt, setDismissedAt] = useLocalStorage<number | null>('installPromptDismissed', null)
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      e.preventDefault()
+      setPromptEvent(e as BeforeInstallPromptEvent)
+    }
+    window.addEventListener('beforeinstallprompt', handler as EventListener)
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener)
+  }, [])
+
+  useEffect(() => {
+    if (dismissedAt && Date.now() - dismissedAt < 7 * 24 * 60 * 60 * 1000) return
+    interface Nav extends Navigator { standalone?: boolean }
+    const nav = navigator as Nav
+    const notStandalone = !window.matchMedia('(display-mode: standalone)').matches && !nav.standalone
+    if (notStandalone && (promptEvent || isiOS())) setShow(true)
+  }, [promptEvent, dismissedAt])
+
+  const dismiss = () => {
+    setShow(false)
+    setDismissedAt(Date.now())
+  }
+
+  const install = async () => {
+    if (promptEvent) {
+      await promptEvent.prompt()
+    }
+    dismiss()
+  }
+
+  if (!show) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <Card className="w-full max-w-sm mx-auto shadow-2xl">
+        <CardHeader className="text-center pb-4">
+          <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+            <Download className="w-8 h-8 text-primary" />
+          </div>
+          <CardTitle className="text-xl font-semibold">Add to Home Screen</CardTitle>
+        </CardHeader>
+        <CardContent className="text-center space-y-4">
+          {promptEvent ? (
+            <p className="text-sm text-muted-foreground">Install this app for quick access.</p>
+          ) : (
+            <p className="text-sm text-muted-foreground">Tap Share and choose "Add to Home Screen".</p>
+          )}
+          <div className="flex gap-3 justify-center">
+            {promptEvent && <Button onClick={install}>Install</Button>}
+            <Button variant="outline" onClick={dismiss}>Dismiss</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,0 +1,38 @@
+import { DownloadCloud, RefreshCw } from 'lucide-react'
+import { useRegisterSW } from 'virtual:pwa-register/react'
+import { Button } from './ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card'
+
+export function UpdatePrompt() {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({ immediate: true })
+
+  if (!needRefresh) return null
+
+  const close = () => setNeedRefresh(false)
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <Card className="w-full max-w-sm mx-auto shadow-2xl">
+        <CardHeader className="text-center pb-4">
+          <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+            <DownloadCloud className="w-8 h-8 text-primary" />
+          </div>
+          <CardTitle className="text-xl font-semibold">Update Available</CardTitle>
+        </CardHeader>
+        <CardContent className="text-center space-y-4">
+          <p className="text-sm text-muted-foreground">A new version of the app is available.</p>
+          <div className="flex gap-3 justify-center">
+            <Button variant="outline" onClick={close}>Later</Button>
+            <Button onClick={() => updateServiceWorker(true)}>
+              <RefreshCw className="w-4 h-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/components/WeatherForecast.test.tsx
+++ b/src/components/WeatherForecast.test.tsx
@@ -3,6 +3,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { WeatherForecast } from './WeatherForecast'
 import * as weatherService from '@/services/weather'
 
+const mockGeo = {
+  getCurrentPosition: vi.fn((cb: any) => cb({ coords: { latitude: 1, longitude: 2 } }))
+} as Geolocation
+
 const queryClient = new QueryClient()
 
 describe('WeatherForecast', () => {
@@ -13,6 +17,7 @@ describe('WeatherForecast', () => {
       precipitation_probability: [5],
       weathercode: [0],
     })
+    Object.defineProperty(global.navigator, 'geolocation', { value: mockGeo, configurable: true })
     const { getByText } = render(
       <QueryClientProvider client={queryClient}>
         <WeatherForecast />
@@ -21,5 +26,6 @@ describe('WeatherForecast', () => {
     await waitFor(() => {
       expect(getByText('12AM')).toBeTruthy()
     })
+    vi.restoreAllMocks()
   })
 })

--- a/src/components/WeatherForecast.tsx
+++ b/src/components/WeatherForecast.tsx
@@ -3,7 +3,8 @@ import { format } from 'date-fns'
 import { Sun, Cloud, CloudRain, CloudSnow, CloudDrizzle, CloudLightning, CloudFog } from 'lucide-react'
 import { Card, CardContent } from './ui/card'
 import type { WeatherData } from '../services/weather'
-import { fetchWeather, DEFAULT_LOCATION } from '../services/weather'
+import { fetchWeather, DEFAULT_LOCATION, type WeatherLocation } from '../services/weather'
+import { useEffect, useState } from 'react'
 
 function weatherIcon(code: number) {
   if (code === 0) return { Icon: Sun, label: 'Clear' }
@@ -17,9 +18,29 @@ function weatherIcon(code: number) {
 }
 
 export function WeatherForecast() {
+  const [location, setLocation] = useState<WeatherLocation>(DEFAULT_LOCATION)
+
+  useEffect(() => {
+    if ('geolocation' in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          setLocation({
+            latitude: pos.coords.latitude,
+            longitude: pos.coords.longitude,
+            timezone: DEFAULT_LOCATION.timezone,
+          })
+        },
+        () => {
+          /* fallback to default */
+        },
+        { enableHighAccuracy: true, maximumAge: 3600000, timeout: 5000 },
+      )
+    }
+  }, [])
+
   const { data, isLoading, error } = useQuery<WeatherData>({
-    queryKey: ['weather', DEFAULT_LOCATION.latitude, DEFAULT_LOCATION.longitude],
-    queryFn: () => fetchWeather(DEFAULT_LOCATION),
+    queryKey: ['weather', location.latitude, location.longitude],
+    queryFn: () => fetchWeather(location),
     staleTime: 1000 * 60 * 5,
   })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,12 @@ import path from 'path'
 
 export default defineConfig({
   plugins: [react()],
-  resolve: { alias: { '@': path.resolve(__dirname, 'src') } },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      'virtual:pwa-register/react': path.resolve(__dirname, 'src/__mocks__/pwa-register-react.ts'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- detect new service worker updates and prompt the user to refresh
- guide users to install the PWA with dismissible popup
- get weather based on geolocation with Singapore fallback
- adjust tests to mock the new modules

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_684107f452fc8324b6268942f7d2853a