### PR TITLE
Fix UI padding and add avatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@netlify/blobs": "^9.1.5",
     "@netlify/functions": "^4.1.2",
+    "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "@tailwindcss/vite": "^4.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@netlify/functions':
         specifier: ^4.1.2
         version: 4.1.2(rollup@2.79.2)
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.10
+        version: 1.1.10(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.6)(react@19.1.0)
@@ -1134,6 +1137,19 @@ packages:
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
 
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -1264,6 +1280,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3895,6 +3920,11 @@ packages:
   urlpattern-polyfill@8.0.2:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5255,6 +5285,19 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.1.6)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.6
+      '@types/react-dom': 19.1.5(@types/react@19.1.6)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.5(@types/react@19.1.6))(@types/react@19.1.6)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.6)(react@19.1.0)
@@ -5369,6 +5412,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.6)(react@19.1.0)
       react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.6
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.1.6)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.6
 
@@ -8161,6 +8211,10 @@ snapshots:
   urlpattern-polyfill@10.1.0: {}
 
   urlpattern-polyfill@8.0.2: {}
+
+  use-sync-external-store@1.5.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   util-deprecate@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+ignoredBuiltDependencies:
+  - '@tailwindcss/oxide'
+  - esbuild

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,7 +157,10 @@ function AppContent() {
     <div className="min-h-screen bg-background pt-safe">
       <InstallPrompt />
       {/* Main Content */}
-      <div className="mx-auto max-w-[480px] p-3 pb-16">
+      <div
+        className="mx-auto max-w-[480px] p-3 pb-20"
+        style={{ paddingBottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
+      >
         {renderTabContent()}
       </div>
       {/* Bottom Navigation */}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -42,7 +42,7 @@ export function About() {
                   />
                 </div>
               </div>
-              <h1 className="text-2xl font-bold mb-2">SG Bus Arrival</h1>
+              <h1 className="text-2xl font-bold tracking-tight mb-2">SG Bus Arrival</h1>
               <p className="text-blue-100 text-sm">
                 Real-time bus tracking for Singapore commuters
               </p>

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -164,7 +164,7 @@ export function HomeTab({
           </div>
           {/* App Title */}
           <div>
-            <h1 className="text-2xl font-bold bg-gradient-to-r from-gray-900 to-gray-700 dark:from-white dark:to-gray-200 bg-clip-text text-transparent">
+            <h1 className="text-2xl font-bold tracking-tight bg-gradient-to-r from-gray-900 to-gray-700 dark:from-white dark:to-gray-200 bg-clip-text text-transparent">
               SG Bus
             </h1>
             <p className="text-sm font-medium bg-gradient-to-r from-gray-900 to-gray-700 dark:from-white dark:to-gray-200 bg-clip-text text-transparent -mt-1">
@@ -191,7 +191,7 @@ export function HomeTab({
         <Card>
           <CardContent className="p-4 text-center">
             <MapPin className="w-10 h-10 mx-auto mb-3 text-muted-foreground" />
-            <h3 className="text-base font-semibold mb-2">No stations configured</h3>
+            <h3 className="text-base font-semibold tracking-tight mb-2">No stations configured</h3>
             <p className="text-sm text-muted-foreground mb-4">
               Add your favorite bus stations to get started
             </p>

--- a/src/components/NotificationsTab.tsx
+++ b/src/components/NotificationsTab.tsx
@@ -22,12 +22,12 @@ export function NotificationsTab() {
 
   return (
     <div className="space-y-3 pb-6">
-      <h2 className="text-xl font-bold">Notifications</h2>
+      <h2 className="text-xl font-bold tracking-tight">Notifications</h2>
       {notifications.length === 0 ? (
         <Card>
           <CardContent className="p-3 text-center">
             <Bell className="w-10 h-10 mx-auto mb-3 text-muted-foreground" />
-            <h3 className="text-base font-semibold mb-2">Bus Notifications</h3>
+            <h3 className="text-base font-semibold tracking-tight mb-2">Bus Notifications</h3>
             <p className="text-sm text-muted-foreground">
               Tap the bell icon on any bus card to get notified before it arrives
             </p>

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react'
 import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar'
+import { User } from 'lucide-react'
 import { PasscodeModal } from './PasscodeModal'
 import { toast } from 'sonner'
 import { format } from 'date-fns'
@@ -102,7 +104,7 @@ export function SettingsTab({
 
   return (
     <div className="space-y-3 pb-6">
-      <h2 className="text-xl font-bold">Settings</h2>
+      <h2 className="text-xl font-bold tracking-tight">Settings</h2>
       {/* Login */}
       <Card>
         <CardHeader className="pb-2 space-y-1">
@@ -115,7 +117,15 @@ export function SettingsTab({
           {email ? (
             <div className="space-y-2">
               <div className="flex items-center justify-between gap-2">
-                <span className="text-sm break-all">{email}</span>
+                <div className="flex items-center gap-2 min-w-0">
+                  <Avatar>
+                    <AvatarImage src="" alt="User avatar" />
+                    <AvatarFallback>
+                      <User className="w-4 h-4" />
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-sm break-all">{email}</span>
+                </div>
                 <Button
                   size="sm"
                   variant="outline"

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/ui.test.tsx
+++ b/src/components/ui/ui.test.tsx
@@ -4,6 +4,7 @@ import { Button } from './button'
 import { Card, CardContent, CardHeader, CardTitle } from './card'
 import { Input } from './input'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs'
+import { Avatar, AvatarFallback } from './avatar'
 
 describe('UI components render', () => {
   it('Badge', () => {
@@ -39,5 +40,13 @@ describe('UI components render', () => {
       </Tabs>
     )
     expect(getByText('A')).toBeTruthy()
+  })
+  it('Avatar', () => {
+    const { getByLabelText } = render(
+      <Avatar>
+        <AvatarFallback aria-label="avatar-icon">U</AvatarFallback>
+      </Avatar>
+    )
+    expect(getByLabelText('avatar-icon')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- add Radix Avatar component and basic tests
- add avatar display in account settings
- bump padding for main layout so bottom nav doesn't overlap content
- improve heading typography
- update pnpm workspace for build approvals

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841275802948324b26489ff15043572