### PR TITLE
Allow custom notification lead time

### DIFF
--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -32,6 +32,7 @@ export function SettingsTab({
   const [lastSync, setLastSync] = useLocalStorage<number>('lastSync', 0)
   const [pendingEmail, setPendingEmail] = useState('')
   const [modalMode, setModalMode] = useState<'enter' | 'setup' | null>(null)
+  const [notifyMinutes, setNotifyMinutes] = useLocalStorage<number>('notifyLeadTime', 2)
 
   const decodeJwt = (token: string) => {
     const base64 = token
@@ -158,6 +159,29 @@ export function SettingsTab({
               <Button type="submit" size="sm">Login</Button>
             </form>
           )}
+        </CardContent>
+      </Card>
+      {/* Notification Settings */}
+      <Card>
+        <CardHeader className="pb-2 space-y-1">
+          <CardTitle className="text-base">Alerts</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Choose how many minutes before arrival you're notified.
+          </p>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              min={0}
+              value={notifyMinutes}
+              onChange={(e) =>
+                setNotifyMinutes(parseInt(e.target.value) || 0)
+              }
+              className="w-20"
+            />
+            <span className="text-sm text-muted-foreground">minutes before</span>
+          </div>
         </CardContent>
       </Card>
       {/* Station Configuration */}

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -175,9 +175,10 @@ export function SettingsTab({
               type="number"
               min={0}
               value={notifyMinutes}
-              onChange={(e) =>
-                setNotifyMinutes(parseInt(e.target.value) || 0)
-              }
+              onChange={(e) => {
+                const minutes = Number(e.target.value)
+                setNotifyMinutes(Number.isNaN(minutes) ? 0 : Math.max(0, minutes))
+              }}
               className="w-20"
             />
             <span className="text-sm text-muted-foreground">minutes before</span>

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -2,9 +2,11 @@ import { toast } from 'sonner'
 import { requestPushSubscription, schedulePush } from '../services/push'
 import type { BusArrival } from '../types'
 import { usePendingNotifications } from './usePendingNotifications'
+import { useLocalStorage } from './useLocalStorage'
 
 export function useNotifications() {
   const { addNotification, removeNotification } = usePendingNotifications()
+  const [notifyMinutes] = useLocalStorage<number>('notifyLeadTime', 2)
 
   const notifyBus = async (bus: BusArrival) => {
     const remainingTime = bus.arrivalTimestamp - Date.now()
@@ -20,7 +22,7 @@ export function useNotifications() {
       return
     }
 
-    const notifyBefore = 2 * 60 * 1000 // 2 minutes
+    const notifyBefore = notifyMinutes * 60 * 1000
     const delay = Math.max(remainingTime - notifyBefore, 0)
     await schedulePush(
       subscription,


### PR DESCRIPTION
## Summary
- make the notification lead time a localStorage value
- expose alert lead time input in settings

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684137d5481483249674feb536028fa2