### PR TITLE
Fix scrolling issue on station cards

### DIFF
--- a/src/components/StationConfig.tsx
+++ b/src/components/StationConfig.tsx
@@ -65,7 +65,6 @@ function SortableStationCard({
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    touchAction: 'none',
     opacity: isDragging ? 0.8 : undefined,
   };
 
@@ -317,7 +316,7 @@ export function StationConfigComponent({
                             {...attributes}
                             {...listeners}
                             ref={setActivatorNodeRef}
-                            className="mt-1 cursor-grab active:cursor-grabbing text-muted-foreground"
+                            className="mt-1 cursor-grab active:cursor-grabbing text-muted-foreground touch-none"
                           >
                             <GripVertical className="w-4 h-4" />
                           </div>


### PR DESCRIPTION
## Summary
- allow scrolling on Station cards by removing global `touchAction:none`
- keep drag handle responsive with `touch-none` class

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841601cd27083249bc7eea03228021c