### PR TITLE
Add Nearby tab showing nearest bus stops

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useNotifications } from './hooks/useNotifications';
 import type { StationConfig, TabType, Theme, StopData, ServiceData } from './types';
 import './App.css';
 import { HomeTab } from './components/HomeTab';
+import { NearbyTab } from './components/NearbyTab';
 import { SettingsTab } from './components/SettingsTab';
 import { NotificationsTab } from './components/NotificationsTab';
 // Import static data directly for instant loading
@@ -126,6 +127,14 @@ function AppContent() {
             refreshAllData={refreshAllData}
             stationConfigs={stationConfigs}
             setActiveTab={setActiveTab}
+            servicesData={servicesDataTyped}
+            stopsData={stopsDataTyped}
+            handleNotify={notifyBus}
+          />
+        );
+      case 'nearby':
+        return (
+          <NearbyTab
             servicesData={servicesDataTyped}
             stopsData={stopsDataTyped}
             handleNotify={notifyBus}

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -1,4 +1,4 @@
-import { Home, Settings, Bell, Info } from 'lucide-react';
+import { Home, Settings, Bell, Info, MapPin } from 'lucide-react';
 import type { TabType } from '../types';
 
 interface BottomNavigationProps {
@@ -9,6 +9,7 @@ interface BottomNavigationProps {
 export function BottomNavigation({ activeTab, onTabChange }: BottomNavigationProps) {
   const tabs = [
     { id: 'home' as const, label: 'Home', icon: Home },
+    { id: 'nearby' as const, label: 'Nearby', icon: MapPin },
     { id: 'settings' as const, label: 'Settings', icon: Settings },
     { id: 'notifications' as const, label: 'Alerts', icon: Bell },
     { id: 'info' as const, label: 'About', icon: Info },

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -22,16 +22,18 @@ interface HomeTabProps {
   handleNotify: (bus: BusArrival) => void;
 }
 
-function StationCard({ 
-  config, 
-  servicesData, 
-  stopsData, 
-  onNotify 
-}: { 
-  config: StationConfig; 
-  servicesData: ServiceData; 
-  stopsData: StopData; 
-  onNotify: (bus: BusArrival) => void; 
+export function StationCard({
+  config,
+  servicesData,
+  stopsData,
+  onNotify,
+  maxItems = Infinity,
+}: {
+  config: StationConfig;
+  servicesData: ServiceData;
+  stopsData: StopData;
+  onNotify: (bus: BusArrival) => void;
+  maxItems?: number;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { data: arrivals = [], isLoading, error } = useQuery<BusArrival[]>({
@@ -51,7 +53,9 @@ function StationCard({
 
   // Determine which buses to show
   const maxVisible = 3;
-  const visibleArrivals = isExpanded ? arrivals : arrivals.slice(0, maxVisible);
+  const visibleArrivals = isExpanded
+    ? arrivals.slice(0, maxItems)
+    : arrivals.slice(0, maxVisible);
   const hasMore = arrivals.length > maxVisible;
 
   return (
@@ -97,7 +101,7 @@ function StationCard({
               />
             ))}
             {/* Expand/Collapse Button */}
-            {hasMore && (
+            {(isExpanded || hasMore) && (
               <div className="pt-2">
                 <Button
                   variant="ghost"
@@ -117,7 +121,7 @@ function StationCard({
                       <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                       </svg>
-                      Show {arrivals.length - maxVisible} More
+                      Show {Math.min(arrivals.length, maxItems) - maxVisible} More
                     </>
                   )}
                 </Button>

--- a/src/components/NearbyTab.test.tsx
+++ b/src/components/NearbyTab.test.tsx
@@ -1,0 +1,52 @@
+import { render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { NearbyTab } from './NearbyTab'
+import * as api from '@/services/api'
+
+const queryClient = new QueryClient()
+
+const stopsData = {
+  '1': [103, 1, 'Stop1', 'Road1'],
+  '2': [104, 1.1, 'Stop2', 'Road2']
+} as any
+
+const servicesData = {
+  '10': { name: 'Ten', routes: [['1', '2']] }
+} as any
+
+vi.mock('@/services/api')
+
+const mockGeoSuccess = {
+  getCurrentPosition: vi.fn((cb) => cb({ coords: { latitude: 1, longitude: 103 } }))
+} as Geolocation
+
+const mockGeoFail = {
+  getCurrentPosition: vi.fn((_s, e) => e && e(new Error('denied')))
+} as Geolocation
+
+describe('NearbyTab', () => {
+  it('shows error when location denied', async () => {
+    Object.defineProperty(global.navigator, 'geolocation', { value: mockGeoFail, configurable: true })
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <NearbyTab stopsData={stopsData} servicesData={servicesData} handleNotify={() => {}} />
+      </QueryClientProvider>
+    )
+    await waitFor(() => {
+      expect(getByText(/Unable/)).toBeTruthy()
+    })
+  })
+
+  it('renders stations on success', async () => {
+    Object.defineProperty(global.navigator, 'geolocation', { value: mockGeoSuccess, configurable: true })
+    ;(api.fetchBusArrivals as any).mockResolvedValue([])
+    const { getByText } = render(
+      <QueryClientProvider client={queryClient}>
+        <NearbyTab stopsData={stopsData} servicesData={servicesData} handleNotify={() => {}} />
+      </QueryClientProvider>
+    )
+    await waitFor(() => {
+      expect(getByText('Stop1 (Road1)')).toBeTruthy()
+    })
+  })
+})

--- a/src/components/NearbyTab.tsx
+++ b/src/components/NearbyTab.tsx
@@ -1,0 +1,106 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Card, CardContent } from './ui/card'
+import { MapPin } from 'lucide-react'
+import { StationCard } from './HomeTab'
+import type { StopData, ServiceData, StationConfig, BusArrival } from '../types'
+
+interface NearbyTabProps {
+  stopsData: StopData
+  servicesData: ServiceData
+  handleNotify: (bus: BusArrival) => void
+}
+
+export function NearbyTab({ stopsData, servicesData, handleNotify }: NearbyTabProps) {
+  const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if ('geolocation' in navigator) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude })
+        },
+        () => {
+          setError('Unable to retrieve your location')
+        },
+        { enableHighAccuracy: true, maximumAge: 600000, timeout: 5000 }
+      )
+    } else {
+      setError('Geolocation not supported')
+    }
+  }, [])
+
+  const stationToBusNumbers = useMemo(() => {
+    const mapping: Record<string, Set<string>> = {}
+    Object.keys(servicesData).forEach(busNo => {
+      servicesData[busNo].routes.forEach(route => {
+        route.forEach(stationId => {
+          if (!mapping[stationId]) {
+            mapping[stationId] = new Set()
+          }
+          mapping[stationId].add(busNo)
+        })
+      })
+    })
+    const res: Record<string, string[]> = {}
+    Object.keys(mapping).forEach(id => {
+      res[id] = Array.from(mapping[id])
+    })
+    return res
+  }, [servicesData])
+
+  const nearbyConfigs = useMemo(() => {
+    if (!coords) return [] as StationConfig[]
+    const { lat, lng } = coords
+    return Object.keys(stopsData)
+      .map(id => {
+        const stop = stopsData[id]
+        const distance = Math.sqrt(
+          Math.pow(stop[1] - lat, 2) + Math.pow(stop[0] - lng, 2)
+        )
+        return { id, distance }
+      })
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, 3)
+      .map(({ id }) => ({
+        stationId: id,
+        busNumbers: stationToBusNumbers[id] || []
+      }))
+  }, [coords, stopsData, stationToBusNumbers])
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="p-4 text-center">
+          <MapPin className="w-10 h-10 mx-auto mb-3 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">{error}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!coords) {
+    return (
+      <Card>
+        <CardContent className="flex justify-center p-6">
+          <MapPin className="w-5 h-5 animate-pulse" />
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-2 pb-6">
+      {nearbyConfigs.map(config => (
+        <StationCard
+          key={config.stationId}
+          config={config}
+          servicesData={servicesData}
+          stopsData={stopsData}
+          onNotify={handleNotify}
+          maxItems={8}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,4 +27,4 @@ export interface WeatherData {
 
 export type Theme = 'light' | 'dark';
 
-export type TabType = 'home' | 'settings' | 'notifications' | 'info'; 
+export type TabType = 'home' | 'nearby' | 'settings' | 'notifications' | 'info';


### PR DESCRIPTION
## Summary
- extend `TabType` to include `nearby`
- add Nearby tab entry in bottom navigation
- export and enhance `StationCard` for reuse
- create new `NearbyTab` component using geolocation
- render `NearbyTab` in `App`
- test NearbyTab component

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b3e71b388324953d57c659ea8eef