### PR TITLE
Improve settings labels and alert feedback

### DIFF
--- a/src/components/BusArrivalCard.tsx
+++ b/src/components/BusArrivalCard.tsx
@@ -122,11 +122,11 @@ export function BusArrivalCard({ bus, routeName, onNotify }: BusArrivalCardProps
           {/* Right Actions */}
           {onNotify && !isArrived && (
             <div className="flex-shrink-0">
-              <Button 
-                variant="ghost" 
+              <Button
+                variant="ghost"
                 size="sm"
                 onClick={() => onNotify(bus)}
-                className="h-8 w-8 p-0 hover:bg-primary/10"
+                className="h-8 w-8 p-0 hover:bg-primary/10 active:bg-primary/20 transition-colors"
               >
                 <Bell className="w-4 h-4" />
               </Button>

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -14,6 +14,9 @@ import { fetchUserSettings, saveUserSettings } from '../services/user'
 import { checkUser, register, login } from '../services/auth'
 import type { StationConfig, StopData, ServiceData } from '../types'
 
+const fontSizeOptions = [14, 16, 18, 20]
+const fontSizeLabels = ['Very Compact', 'Compact', 'Default', 'Large']
+
 interface SettingsTabProps {
   stationConfigs: StationConfig[];
   setStationConfigs: (configs: StationConfig[]) => void;
@@ -38,6 +41,8 @@ export function SettingsTab({
   const [pendingEmail, setPendingEmail] = useState('')
   const [modalMode, setModalMode] = useState<'enter' | 'setup' | null>(null)
   const [notifyMinutes, setNotifyMinutes] = useLocalStorage<number>('notifyLeadTime', 2)
+
+  const fontSizeIndex = Math.max(0, fontSizeOptions.indexOf(fontSize))
 
   const decodeJwt = (token: string) => {
     const base64 = token
@@ -193,23 +198,23 @@ export function SettingsTab({
       {/* Font Size Settings */}
       <Card>
         <CardHeader className="pb-2 space-y-1">
-          <CardTitle className="text-base">Font Size</CardTitle>
+          <CardTitle className="text-base">Text Size</CardTitle>
           <p className="text-sm text-muted-foreground">
-            Adjust the app's text size to your preference.
+            Adjust how large or small text appears.
           </p>
         </CardHeader>
         <CardContent className="pt-0">
           <div className="flex items-center gap-2">
             <Slider
-              min={12}
-              max={20}
+              min={0}
+              max={3}
               step={1}
-              value={[fontSize]}
-              onValueChange={(v) => setFontSize(v[0])}
+              value={[fontSizeIndex]}
+              onValueChange={(v) => setFontSize(fontSizeOptions[v[0]])}
               className="flex-1"
             />
             <span className="text-sm text-muted-foreground">
-              {fontSize}px
+              {fontSizeLabels[fontSizeIndex]}
             </span>
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary
- tweak Settings page to show simple text size labels
- add pressed feedback to bus alert button

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852b85667348324bf6b79bd6cc2a155