### PR TITLE
Add basic/advance mode setting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,8 @@ const queryClient = new QueryClient({
 });
 
 function AppContent() {
-  const [activeTab, setActiveTab] = useState<TabType>('home');
+  const [uiMode, setUiMode] = useLocalStorage<'advance' | 'basic'>('uiMode', 'advance');
+  const [activeTab, setActiveTab] = useState<TabType>(() => (uiMode === 'basic' ? 'nearby' : 'home'));
   const [theme, setTheme] = useLocalStorage<Theme>('theme', 'light');
   const [fontSize, setFontSize] = useLocalStorage<number>('fontSize', 16);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -56,6 +57,13 @@ function AppContent() {
       }
     }
   }, [activeTab]);
+
+  // Adjust tab when switching modes
+  useEffect(() => {
+    if (uiMode === 'basic' && (activeTab === 'home' || activeTab === 'notifications')) {
+      setActiveTab('nearby');
+    }
+  }, [uiMode]);
 
   // Offline detection
   const { isOffline, isRetrying, retryCount, lastRetryTime, manualRetry } = useOfflineDetection();
@@ -130,6 +138,7 @@ function AppContent() {
             servicesData={servicesDataTyped}
             stopsData={stopsDataTyped}
             handleNotify={notifyBus}
+            showRouteName={uiMode === 'advance'}
           />
         );
       case 'nearby':
@@ -138,6 +147,7 @@ function AppContent() {
             servicesData={servicesDataTyped}
             stopsData={stopsDataTyped}
             handleNotify={notifyBus}
+            showRouteName={uiMode === 'advance'}
           />
         );
       case 'settings':
@@ -149,6 +159,8 @@ function AppContent() {
             servicesData={servicesDataTyped}
             fontSize={fontSize}
             setFontSize={setFontSize}
+            uiMode={uiMode}
+            setUiMode={setUiMode}
           />
         );
       case 'notifications':
@@ -166,6 +178,7 @@ function AppContent() {
           servicesData={servicesDataTyped}
           stopsData={stopsDataTyped}
           handleNotify={notifyBus}
+          showRouteName={uiMode === 'advance'}
         />;
     }
   };
@@ -181,7 +194,7 @@ function AppContent() {
         {renderTabContent()}
       </div>
       {/* Bottom Navigation */}
-      <BottomNavigation activeTab={activeTab} onTabChange={setActiveTab} />
+      <BottomNavigation activeTab={activeTab} onTabChange={setActiveTab} uiMode={uiMode} />
       {/* Toast Container */}
       <Toaster
         richColors

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -4,16 +4,19 @@ import type { TabType } from '../types';
 interface BottomNavigationProps {
   activeTab: TabType;
   onTabChange: (tab: TabType) => void;
+  uiMode: 'advance' | 'basic';
 }
 
-export function BottomNavigation({ activeTab, onTabChange }: BottomNavigationProps) {
+export function BottomNavigation({ activeTab, onTabChange, uiMode }: BottomNavigationProps) {
   const tabs = [
     { id: 'home' as const, label: 'Home', icon: Home },
     { id: 'nearby' as const, label: 'Nearby', icon: MapPin },
     { id: 'settings' as const, label: 'Settings', icon: Settings },
     { id: 'notifications' as const, label: 'Alerts', icon: Bell },
     { id: 'info' as const, label: 'About', icon: Info },
-  ];
+  ].filter(tab =>
+    uiMode === 'advance' ? true : tab.id !== 'home' && tab.id !== 'notifications'
+  );
 
   return (
     <nav

--- a/src/components/HomeTab.tsx
+++ b/src/components/HomeTab.tsx
@@ -20,6 +20,7 @@ interface HomeTabProps {
   servicesData: ServiceData;
   stopsData: StopData;
   handleNotify: (bus: BusArrival) => void;
+  showRouteName: boolean;
 }
 
 export function StationCard({
@@ -28,12 +29,14 @@ export function StationCard({
   stopsData,
   onNotify,
   maxItems = Infinity,
+  showRouteName,
 }: {
   config: StationConfig;
   servicesData: ServiceData;
   stopsData: StopData;
   onNotify: (bus: BusArrival) => void;
   maxItems?: number;
+  showRouteName: boolean;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { data: arrivals = [], isLoading, error } = useQuery<BusArrival[]>({
@@ -96,7 +99,7 @@ export function StationCard({
               <BusArrivalCard
                 key={`${bus.busNo}-${busIndex}`}
                 bus={bus}
-                routeName={servicesData[bus.busNo]?.name}
+                routeName={showRouteName ? servicesData[bus.busNo]?.name : undefined}
                 onNotify={onNotify}
               />
             ))}
@@ -150,6 +153,7 @@ export function HomeTab({
   servicesData,
   stopsData,
   handleNotify,
+  showRouteName,
 }: HomeTabProps) {
   return (
     <div className="space-y-3 pb-6">
@@ -213,6 +217,7 @@ export function HomeTab({
               servicesData={servicesData}
               stopsData={stopsData}
               onNotify={handleNotify}
+              showRouteName={showRouteName}
             />
           ))}
         </div>

--- a/src/components/NearbyTab.test.tsx
+++ b/src/components/NearbyTab.test.tsx
@@ -29,7 +29,7 @@ describe('NearbyTab', () => {
     Object.defineProperty(global.navigator, 'geolocation', { value: mockGeoFail, configurable: true })
     const { getByText } = render(
       <QueryClientProvider client={queryClient}>
-        <NearbyTab stopsData={stopsData} servicesData={servicesData} handleNotify={() => {}} />
+        <NearbyTab stopsData={stopsData} servicesData={servicesData} handleNotify={() => {}} showRouteName={true} />
       </QueryClientProvider>
     )
     await waitFor(() => {
@@ -42,7 +42,7 @@ describe('NearbyTab', () => {
     ;(api.fetchBusArrivals as any).mockResolvedValue([])
     const { getByText } = render(
       <QueryClientProvider client={queryClient}>
-        <NearbyTab stopsData={stopsData} servicesData={servicesData} handleNotify={() => {}} />
+        <NearbyTab stopsData={stopsData} servicesData={servicesData} handleNotify={() => {}} showRouteName={true} />
       </QueryClientProvider>
     )
     await waitFor(() => {

--- a/src/components/NearbyTab.tsx
+++ b/src/components/NearbyTab.tsx
@@ -8,9 +8,10 @@ interface NearbyTabProps {
   stopsData: StopData
   servicesData: ServiceData
   handleNotify: (bus: BusArrival) => void
+  showRouteName: boolean
 }
 
-export function NearbyTab({ stopsData, servicesData, handleNotify }: NearbyTabProps) {
+export function NearbyTab({ stopsData, servicesData, handleNotify, showRouteName }: NearbyTabProps) {
   const [coords, setCoords] = useState<{ lat: number; lng: number } | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -99,6 +100,7 @@ export function NearbyTab({ stopsData, servicesData, handleNotify }: NearbyTabPr
           stopsData={stopsData}
           onNotify={handleNotify}
           maxItems={8}
+          showRouteName={showRouteName}
         />
       ))}
     </div>

--- a/src/components/SettingsTab.test.tsx
+++ b/src/components/SettingsTab.test.tsx
@@ -8,6 +8,8 @@ const props = {
   servicesData: {},
   fontSize: 16,
   setFontSize: () => {},
+  uiMode: 'advance' as const,
+  setUiMode: () => {},
 }
 
 describe('SettingsTab', () => {

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -3,6 +3,7 @@ import { Card, CardHeader, CardTitle, CardContent } from './ui/card'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { Slider } from './ui/slider'
+import { Tabs, TabsList, TabsTrigger } from './ui/tabs'
 import { Avatar, AvatarFallback } from './ui/avatar'
 import { User } from 'lucide-react'
 import { PasscodeModal } from './PasscodeModal'
@@ -24,6 +25,8 @@ interface SettingsTabProps {
   servicesData: ServiceData;
   fontSize: number;
   setFontSize: (size: number) => void;
+  uiMode: 'advance' | 'basic';
+  setUiMode: (mode: 'advance' | 'basic') => void;
 }
 
 export function SettingsTab({
@@ -33,6 +36,8 @@ export function SettingsTab({
   servicesData,
   fontSize,
   setFontSize,
+  uiMode,
+  setUiMode,
 }: SettingsTabProps) {
   const [email, setEmail] = useLocalStorage<string>('userEmail', '')
   const [emailInput, setEmailInput] = useState(email)
@@ -116,7 +121,25 @@ export function SettingsTab({
   return (
     <div className="space-y-3 pb-6">
       <h2 className="text-xl font-bold">Settings</h2>
+      {/* Mode Selection */}
+      <Card>
+        <CardHeader className="pb-2 space-y-1">
+          <CardTitle className="text-base">Mode</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Choose between advance and basic interfaces.
+          </p>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Tabs value={uiMode} onValueChange={(v) => setUiMode(v as 'advance' | 'basic')}>
+            <TabsList>
+              <TabsTrigger value="advance">Advance</TabsTrigger>
+              <TabsTrigger value="basic">Basic</TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </CardContent>
+      </Card>
       {/* Login */}
+      {uiMode === 'advance' && (
       <Card>
         <CardHeader className="pb-2 space-y-1">
           <CardTitle className="text-base">Account</CardTitle>
@@ -171,6 +194,7 @@ export function SettingsTab({
           )}
         </CardContent>
       </Card>
+      )}
       {/* Notification Settings */}
       <Card>
         <CardHeader className="pb-2 space-y-1">
@@ -225,6 +249,7 @@ export function SettingsTab({
         onUpdateConfigs={setStationConfigs}
         stopsData={stopsData}
         servicesData={servicesData}
+        showAddStation={uiMode === 'advance'}
       />
       <PasscodeModal
         mode={modalMode || 'enter'}

--- a/src/components/StationConfig.tsx
+++ b/src/components/StationConfig.tsx
@@ -39,6 +39,7 @@ interface StationConfigProps {
   onUpdateConfigs: (configs: StationConfig[]) => void;
   stopsData: StopData;
   servicesData: ServiceData;
+  showAddStation?: boolean;
 }
 
 function SortableStationCard({
@@ -75,11 +76,12 @@ function SortableStationCard({
   );
 }
 
-export function StationConfigComponent({ 
-  stationConfigs, 
-  onUpdateConfigs, 
-  stopsData, 
-  servicesData 
+export function StationConfigComponent({
+  stationConfigs,
+  onUpdateConfigs,
+  stopsData,
+  servicesData,
+  showAddStation = true,
 }: StationConfigProps) {
   const [newStationInput, setNewStationInput] = useState('');
   const [stationSuggestions, setStationSuggestions] = useState<StationSuggestion[]>([]);
@@ -253,52 +255,54 @@ export function StationConfigComponent({
 
   return (
     <div className="space-y-6">
-      <Card>
-        <CardHeader className="space-y-1">
-          <CardTitle className="flex items-center">
-            <Plus className="mr-2 w-5 h-5" />
-            Add Bus Station
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Nearby stops will be suggested using your location. Please allow access.
-          </p>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={addStation} className="flex gap-2 relative">
-            <div className="relative flex-1">
-              <Input
-                placeholder="Enter Station ID or Name"
-                value={newStationInput}
-                onChange={(e) => handleStationInputChange(e.target.value)}
-                onFocus={handleStationInputFocus}
-                onBlur={() => {
-                  setTimeout(() => {
-                    setStationSuggestions([])
-                  }, 100)
-                }}
-                className="text-base placeholder:text-base"
-              />
-              {stationSuggestions.length > 0 && (
-                <div className="absolute top-full left-0 w-full bg-background border border-border rounded-md shadow-lg z-10 max-h-48 overflow-y-auto">
-                  {stationSuggestions.map((suggestion, index) => (
-                    <div
-                      key={index}
-                      className="p-3 hover:bg-accent cursor-pointer text-sm border-b border-border/50 last:border-b-0"
-                      onClick={() => handleStationSelect(suggestion)}
-                    >
-                      <div className="font-medium text-foreground">{suggestion.name}</div>
-                      <div className="text-xs text-muted-foreground">{suggestion.road} • {suggestion.stationId}</div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-            <Button type="submit" size="sm">
-              <Plus className="w-4 h-4" />
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+      {showAddStation !== false && (
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="flex items-center">
+              <Plus className="mr-2 w-5 h-5" />
+              Add Bus Station
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Nearby stops will be suggested using your location. Please allow access.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={addStation} className="flex gap-2 relative">
+              <div className="relative flex-1">
+                <Input
+                  placeholder="Enter Station ID or Name"
+                  value={newStationInput}
+                  onChange={(e) => handleStationInputChange(e.target.value)}
+                  onFocus={handleStationInputFocus}
+                  onBlur={() => {
+                    setTimeout(() => {
+                      setStationSuggestions([])
+                    }, 100)
+                  }}
+                  className="text-base placeholder:text-base"
+                />
+                {stationSuggestions.length > 0 && (
+                  <div className="absolute top-full left-0 w-full bg-background border border-border rounded-md shadow-lg z-10 max-h-48 overflow-y-auto">
+                    {stationSuggestions.map((suggestion, index) => (
+                      <div
+                        key={index}
+                        className="p-3 hover:bg-accent cursor-pointer text-sm border-b border-border/50 last:border-b-0"
+                        onClick={() => handleStationSelect(suggestion)}
+                      >
+                        <div className="font-medium text-foreground">{suggestion.name}</div>
+                        <div className="text-xs text-muted-foreground">{suggestion.road} • {suggestion.stationId}</div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <Button type="submit" size="sm">
+                <Plus className="w-4 h-4" />
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      )}
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext items={stationConfigs.map((s) => s.stationId)} strategy={verticalListSortingStrategy}>


### PR DESCRIPTION
## Summary
- implement `uiMode` setting stored in `localStorage`
- add mode toggle in settings
- hide account and add station options in basic mode
- filter navigation tabs by mode
- show or hide route names in bus cards
- update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ba4486c88324a528d671ff0cc63f