### PR TITLE
Add theme toggle in settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,11 +159,13 @@ function AppContent() {
             setStationConfigs={setStationConfigs}
             stopsData={stopsDataTyped}
             servicesData={servicesDataTyped}
-            fontSize={fontSize}
-            setFontSize={setFontSize}
-            uiMode={uiMode}
-            setUiMode={setUiMode}
-          />
+          fontSize={fontSize}
+          setFontSize={setFontSize}
+          uiMode={uiMode}
+          setUiMode={setUiMode}
+          theme={theme}
+          toggleTheme={toggleTheme}
+        />
         );
       case 'notifications':
         return <NotificationsTab />;

--- a/src/components/SettingsTab.test.tsx
+++ b/src/components/SettingsTab.test.tsx
@@ -10,11 +10,18 @@ const props = {
   setFontSize: () => {},
   uiMode: 'advance' as const,
   setUiMode: () => {},
+  theme: 'light' as const,
+  toggleTheme: () => {},
 }
 
 describe('SettingsTab', () => {
   it('renders heading', () => {
     const { getByText } = render(<SettingsTab {...props} />)
     expect(getByText('Settings')).toBeTruthy()
+  })
+
+  it('shows theme toggle', () => {
+    const { getByText } = render(<SettingsTab {...props} />)
+    expect(getByText('Theme')).toBeTruthy()
   })
 })

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -5,7 +5,7 @@ import { Input } from './ui/input'
 import { Slider } from './ui/slider'
 import { Tabs, TabsList, TabsTrigger } from './ui/tabs'
 import { Avatar, AvatarFallback } from './ui/avatar'
-import { User, Rocket, Circle } from 'lucide-react'
+import { User, Rocket, Circle, Moon, Sun } from 'lucide-react'
 import { PasscodeModal } from './PasscodeModal'
 import { toast } from 'sonner'
 import { format } from 'date-fns'
@@ -13,7 +13,7 @@ import { StationConfigComponent } from './StationConfig'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import { fetchUserSettings, saveUserSettings } from '../services/user'
 import { checkUser, register, login } from '../services/auth'
-import type { StationConfig, StopData, ServiceData } from '../types'
+import type { StationConfig, StopData, ServiceData, Theme } from '../types'
 
 const fontSizeOptions = [14, 16, 18, 20]
 const fontSizeLabels = ['Very Compact', 'Compact', 'Default', 'Large']
@@ -27,6 +27,8 @@ interface SettingsTabProps {
   setFontSize: (size: number) => void;
   uiMode: 'advance' | 'basic';
   setUiMode: (mode: 'advance' | 'basic') => void;
+  theme: Theme;
+  toggleTheme: () => void;
 }
 
 export function SettingsTab({
@@ -38,6 +40,8 @@ export function SettingsTab({
   setFontSize,
   uiMode,
   setUiMode,
+  theme,
+  toggleTheme,
 }: SettingsTabProps) {
   const [email, setEmail] = useLocalStorage<string>('userEmail', '')
   const [emailInput, setEmailInput] = useState(email)
@@ -146,6 +150,35 @@ export function SettingsTab({
               </TabsTrigger>
             </TabsList>
           </Tabs>
+        </CardContent>
+      </Card>
+      {/* Theme Toggle */}
+      <Card>
+        <CardHeader className="pb-2 space-y-1">
+          <CardTitle className="text-base">Theme</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Switch between light and dark mode.
+          </p>
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={toggleTheme}
+            className="flex items-center gap-2"
+          >
+            {theme === 'light' ? (
+              <>
+                <Moon className="w-4 h-4" />
+                <span>Dark</span>
+              </>
+            ) : (
+              <>
+                <Sun className="w-4 h-4" />
+                <span>Light</span>
+              </>
+            )}
+          </Button>
         </CardContent>
       </Card>
       {/* Login */}


### PR DESCRIPTION
## Summary
- include theme toggle in SettingsTab
- pass `theme` and `toggleTheme` props from App
- update tests for SettingsTab

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6852e4f1593c8324acabde93486512ac