### PR TITLE
Keep arrived buses visible

### DIFF
--- a/src/components/BusArrivalCard.tsx
+++ b/src/components/BusArrivalCard.tsx
@@ -31,11 +31,11 @@ export function BusArrivalCard({ bus, routeName, onNotify }: BusArrivalCardProps
   
   const getTimeStatus = () => {
     if (isArrived) {
-      if (timePassedSinceArrival < 60000) { // Less than 1 minute ago
-        return `Arrived ${seconds}s ago`;
-      } else {
-        return `Arrived ${minutes}m ago`;
+      const sinceSeconds = Math.floor(timePassedSinceArrival / 1000);
+      if (sinceSeconds < 120) {
+        return `Arrived ${sinceSeconds}s ago`;
       }
+      return 'Arrived';
     } else {
       return minutes === 0 ? `${seconds}s` : `${minutes}m ${seconds}s`;
     }


### PR DESCRIPTION
## Summary
- track recent arrivals in StationCard and keep them around for 2 minutes
- show seconds since arrival for up to 2 minutes

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e9495b98832480a8e3cb07f61054